### PR TITLE
Added Inleads Action Destination

### DIFF
--- a/packages/destination-actions/src/destinations/inleads-ai/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/inleads-ai/__tests__/index.test.ts
@@ -1,0 +1,34 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Definition from '../index'
+import { IntegrationBaseUrl } from '../contants'
+
+export const API_KEY = 'testInleadsApiKey'
+
+const testDestination = createTestIntegration(Definition)
+
+beforeAll(() => {
+  nock.disableNetConnect()
+})
+
+afterAll(() => {
+  nock.enableNetConnect()
+  nock.cleanAll()
+})
+
+describe('InleadsAI', () => {
+  describe('testAuthentication', () => {
+    it('should validate authentication with apiKey', async () => {
+      nock(`${IntegrationBaseUrl}/events/validate/key`)
+        .post('*', {}, {
+          reqheaders: {
+            Authorization: `Basic ${API_KEY}`
+          }
+        })
+        .reply(200, {})
+
+
+      await expect(testDestination.testAuthentication({ apiKey: API_KEY })).resolves.not.toThrowError()
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/inleads-ai/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/inleads-ai/__tests__/snapshot.test.ts
@@ -1,0 +1,77 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = '{{destination}}'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/inleads-ai/common-fields.ts
+++ b/packages/destination-actions/src/destinations/inleads-ai/common-fields.ts
@@ -1,0 +1,155 @@
+import { ActionDefinition } from '@segment/actions-core'
+import { Settings } from './generated-types'
+
+export const commonFields: ActionDefinition<Settings>['fields'] = {
+  userMeta: {
+    label: 'User Metadata',
+    type: 'object',
+    description: 'User metadata including IP, Location, etc.',
+    default: {
+      ip: { '@path': '$.context.ip' },
+      latitude: { '@path': '$.context.location.latitude' },
+      longitude: { '@path': '$.context.location.longitude' },
+      country: { '@path': '$.context.location.country' },
+      city: { '@path': '$.context.location.city' },
+      browser: { '@path': '$.context.userAgent' },
+      os: { '@path': '$.context.os.name' },
+      osVersion: { '@path': '$.context.os.version' },
+      deviceType: { '@path': '$.context.device.type' },
+      deviceVendor: { '@path': '$.context.device.manufacturer' },
+      deviceModel: { '@path': '$.context.device.model' },
+      timeZone: { '@path': '$.context.timezone' },
+    },
+  },
+  anonymous_id: {
+    type: 'string',
+    allowNull: true,
+    required: false,
+    description: 'User Anonymous id',
+    label: 'Anonymous ID',
+    default: { '@path': '$.anonymousId' }
+  },
+  event_id: {
+    type: 'string',
+    required: false,
+    description: 'The ID of the event.',
+    label: 'Event ID',
+    default: { '@path': '$.messageId' }
+  },
+  url: {
+    type: 'string',
+    required: false,
+    description: 'The URL of the page where the event occurred.',
+    label: 'URL',
+    default: { '@path': '$.context.page.url' }
+  },
+  referer: {
+    type: 'string',
+    required: false,
+    description: 'The referrer of the page where the event occurred.',
+    label: 'Referrer',
+    default: { '@path': '$.context.page.referrer' }
+  },
+  user_language: {
+    type: 'string',
+    required: false,
+    description: 'The language of the browser.',
+    label: 'User Language',
+    default: { '@path': '$.context.locale' }
+  },
+  utc_time: {
+    type: 'string',
+    required: false,
+    description: 'The time of the event in UTC.',
+    label: 'UTC Time',
+    default: { '@path': '$.timestamp' }
+  },
+  utm: {
+    type: 'object',
+    required: false,
+    description: 'Information about the UTM parameters.',
+    label: 'UTM',
+    properties: {
+      source: {
+        label: 'Source',
+        description: 'The source of the campaign.',
+        type: 'string'
+      },
+      medium: {
+        label: 'Medium',
+        description: 'The medium of the campaign.',
+        type: 'string'
+      },
+      name: {
+        label: 'Name',
+        description: 'The name of the campaign.',
+        type: 'string'
+      },
+      term: {
+        label: 'Term',
+        description: 'The term of the campaign.',
+        type: 'string'
+      },
+      content: {
+        label: 'Content',
+        description: 'The content of the campaign.',
+        type: 'string'
+      }
+    },
+    default: {
+      source: { '@path': '$.context.campaign.source' },
+      medium: { '@path': '$.context.campaign.medium' },
+      name: { '@path': '$.context.campaign.name' },
+      term: { '@path': '$.context.campaign.term' },
+      content: { '@path': '$.context.campaign.content' }
+    }
+  },
+  screen: {
+    type: 'object',
+    required: false,
+    description: 'Information about the screen.',
+    label: 'Screen',
+    properties: {
+      height: {
+        label: 'Height',
+        description: 'The height of the screen.',
+        type: 'integer'
+      },
+      width: {
+        label: 'Width',
+        description: 'The width of the screen.',
+        type: 'integer'
+      },
+      density: {
+        label: 'Density',
+        description: 'The density of the screen.',
+        type: 'number'
+      }
+    },
+    default: {
+      height: { '@path': '$.context.screen.height' },
+      width: { '@path': '$.context.screen.width' },
+      density: { '@path': '$.context.screen.density' }
+    }
+  },
+  timezone: {
+    type: 'string',
+    required: false,
+    description: 'The timezone of the browser.',
+    label: 'Timezone',
+    default: {
+      '@if': {
+        exists: { '@path': '$.context.timezone' },
+        then: { '@path': '$.context.timezone' },
+        else: { '@path': '$.properties.timezone' }
+      }
+    }
+  },
+  source_ip: {
+    type: 'string',
+    required: false,
+    description: 'The IP address of the user.',
+    label: 'IP Address',
+    default: { '@path': '$.context.ip' }
+  }
+}

--- a/packages/destination-actions/src/destinations/inleads-ai/contants.ts
+++ b/packages/destination-actions/src/destinations/inleads-ai/contants.ts
@@ -1,0 +1,4 @@
+export const IntegrationName = "Inleads AI";
+export const IntegrationWebsite = "inleads.ai";
+export const IntegrationBaseUrl = "https://nagendra.loca.lt";
+export const PartnerActionName = "postToInleadsAI";

--- a/packages/destination-actions/src/destinations/inleads-ai/generated-types.ts
+++ b/packages/destination-actions/src/destinations/inleads-ai/generated-types.ts
@@ -1,0 +1,17 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Your InLeads API Key. You can find your API Key in your inleads.ai settings.
+   */
+  apiKey: string
+}
+
+export interface Payload {
+  /**
+   * Segment Event Payload
+   */
+  segmentEventData: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/inleads-ai/group/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/inleads-ai/group/__tests__/index.test.ts
@@ -1,0 +1,109 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import { API_KEY } from '../../__tests__/index.test'
+
+const testDestination = createTestIntegration(Destination)
+
+beforeAll(() => {
+  nock.disableNetConnect()
+})
+
+afterAll(() => {
+  nock.enableNetConnect()
+  nock.cleanAll()
+})
+
+const inleadsGroupData = {
+  account_id: {
+    '@path': '$.groupId'
+  },
+  name: {
+    '@if': {
+      exists: { '@path': '$.traits.name' },
+      then: { '@path': '$.traits.name' },
+      else: { '@path': '$.properties.name' }
+    }
+  },
+  created_at: {
+    '@path': '$.traits.created_at'
+  },
+  traits: {
+    '@path': '$.traits'
+  },
+  plan: {
+    '@path': '$.traits.plan'
+  },
+  industry: {
+    '@path': '$.traits.industry'
+  },
+  website: {
+    '@path': '$.traits.website'
+  }
+}
+
+describe('InleadsAI.group', () => {
+  test('Should throw an error if `account_id or` `name` is not defined', async () => {
+    const event = createTestEvent({
+      type: 'group',
+      traits: {
+        email: 'test@company.com'
+      },
+      groupId: 'test@test.com'
+    })
+
+    await expect(
+      testDestination.testAction('group', {
+        event,
+        mapping: inleadsGroupData
+      })
+    ).rejects.toThrowError()
+  })
+
+  test('Should throw an error if apiKey is not defined', async () => {
+    const event = createTestEvent({
+      type: 'group',
+      traits: {
+        name: 'test'
+      },
+      groupId: '123456'
+    })
+
+    await expect(
+      testDestination.testAction('group', {
+        event,
+        mapping: inleadsGroupData,
+        settings: {
+          apiKey: API_KEY
+        }
+      })
+    ).rejects.toThrowError()
+  })
+
+  test('Should send an group event to InleadsAI', async () => {
+    // Mock: Segment group Call
+    nock("https://server.inleads.ai")
+      .post('/events/track', {
+        apiKey: API_KEY
+      })
+      .reply(200, { success: true })
+
+    const event = createTestEvent({
+      type: 'group',
+      traits: {
+        name: 'test'
+      },
+      groupId: '123456'
+    })
+
+    const responses = await testDestination.testAction('group', {
+      event,
+      mapping: inleadsGroupData,
+      settings: {
+        apiKey: API_KEY
+      }
+    })
+
+    expect(responses[0].status).toEqual(200)
+  })
+})

--- a/packages/destination-actions/src/destinations/inleads-ai/group/index.ts
+++ b/packages/destination-actions/src/destinations/inleads-ai/group/index.ts
@@ -1,0 +1,84 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings,Payload } from '../generated-types'
+import { commonFields } from '../common-fields'
+import { IntegrationBaseUrl, IntegrationName } from '../contants'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Group',
+  description: `Send group calls to ${IntegrationName}.`,
+  defaultSubscription: 'type = "group"',
+  fields: {
+    account_id: {
+      type: 'string',
+      required: true,
+      description: 'The External ID of the account to send properties for',
+      label: 'Account id',
+      default: {
+        '@if': {
+          exists: { '@path': '$.context.group_id' },
+          then: { '@path': '$.context.group_id' },
+          else: { '@path': '$.groupId' }
+        }
+      }
+    },
+    user_id: {
+      type: 'string',
+      description: 'The ID associated with the user',
+      label: 'User ID',
+      default: { '@path': '$.userId' }
+    },
+    name: {
+      type: 'string',
+      required: true,
+      description: 'The Account name',
+      label: 'Account name',
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.name' },
+          then: { '@path': '$.traits.name' },
+          else: { '@path': '$.properties.name' }
+        }
+      }
+    },
+    created_at: {
+      type: 'string',
+      required: false,
+      description:
+        'The timestamp when the account was created, represented in the ISO-8601 date format. For instance, "2023-09-26T15:30:00Z".',
+      label: 'Account created at',
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.created_at' },
+          then: { '@path': '$.traits.created_at' },
+          else: { '@path': '$.traits.createdAt' }
+        }
+      }
+    },
+    traits: {
+      type: 'object',
+      required: false,
+      description: 'The properties of the account',
+      label: 'Account properties',
+      default: { '@path': '$.traits' }
+    },
+    website: {
+      type: 'string',
+      required: false,
+      description: 'The account website',
+      label: 'Account website',
+      default: { '@path': '$.traits.website' }
+    },
+    ...commonFields
+  },
+  perform: (request, data) => {
+    return request(`${IntegrationBaseUrl}/events/track`, {
+      method: 'post',
+      headers: {
+        Authorization: `Basic ${data.settings.apiKey}`
+      },
+      json: {} // validateInput(data.settings, data.payload, 'track')
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/inleads-ai/identify/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/inleads-ai/identify/__tests__/index.test.ts
@@ -1,0 +1,218 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import { API_KEY } from '../../__tests__/index.test'
+
+const testDestination = createTestIntegration(Destination)
+
+beforeAll(() => {
+  nock.disableNetConnect()
+})
+
+afterAll(() => {
+  nock.enableNetConnect()
+  nock.cleanAll()
+})
+
+const inleadsIdentifyData = {
+  user_id: {
+    '@path': '$.userId'
+  },
+  name: {
+    '@if': {
+      exists: { '@path': '$.traits.name' },
+      then: { '@path': '$.traits.name' },
+      else: { '@path': '$.properties.name' }
+    }
+  },
+  first_name: {
+    '@if': {
+      exists: { '@path': '$.traits.first_name' },
+      then: { '@path': '$.traits.first_name' },
+      else: { '@path': '$.properties.first_name' }
+    }
+  },
+  last_name: {
+    '@if': {
+      exists: { '@path': '$.traits.last_name' },
+      then: { '@path': '$.traits.last_name' },
+      else: { '@path': '$.properties.last_name' }
+    }
+  },
+  email: {
+    '@if': {
+      exists: { '@path': '$.traits.email' },
+      then: { '@path': '$.traits.email' },
+      else: { '@path': '$.properties.email' }
+    }
+  },
+  created_at: {
+    '@path': '$.traits.created_at'
+  },
+  traits: {
+    '@path': '$.traits'
+  }
+}
+
+describe('InleadsAI.identify', () => {
+  test('Should throw an error if `user_id` is not defined', async () => {
+    const event = createTestEvent({
+      type: 'identify',
+      traits: {
+        name: 'test',
+        email: 'test@company.com'
+      },
+      properties: {
+        timezone: 'America/New_York'
+      }
+    })
+
+    await expect(
+      testDestination.testAction('identify', {
+        event,
+        mapping: inleadsIdentifyData,
+        settings: {
+          apiKey: API_KEY
+        }
+      })
+    ).rejects.toThrowError()
+  })
+
+  test('Should throw an error if both `name` and `first_name` & `last_name` are not defined', async () => {
+    const event = createTestEvent({
+      type: 'identify',
+      traits: {
+        email: 'test@company.com'
+      },
+      properties: {
+        timezone: 'America/New_York'
+      },
+      userId: '123456'
+    })
+
+    await expect(
+      testDestination.testAction('identify', {
+        event,
+        mapping: inleadsIdentifyData,
+        settings: {
+          apiKey: API_KEY
+        }
+      })
+    ).rejects.toThrowError()
+  })
+
+  test('Should not throw error if name is defined and first and last name are not', async () => {
+    nock("https://server.inleads.ai")
+      .post('/events/track', {
+        apiKey: API_KEY
+      })
+      .reply(200, { success: true })
+    const event = createTestEvent({
+      type: 'identify',
+      traits: {
+        name: 'test',
+        email: 'test@company.com'
+      },
+      properties: {
+        timezone: 'America/New_York'
+      },
+      userId: '123456'
+    })
+
+    await expect(
+      testDestination.testAction('identify', {
+        event,
+        mapping: inleadsIdentifyData,
+        settings: {
+          apiKey: API_KEY
+        }
+      })
+    ).resolves.not.toThrowError()
+  })
+
+  test('Should not throw error if first_name and last_name are defined and name is not', async () => {
+    nock("https://server.inleads.ai")
+      .post('/events/track', {
+        apiKey: API_KEY
+      })
+      .reply(200, { success: true })
+    const event = createTestEvent({
+      type: 'identify',
+      traits: {
+        first_name: 'test',
+        last_name: 'test',
+        email: 'test@company.com'
+      },
+      properties: {
+        timezone: 'America/New_York'
+      },
+      userId: '123456'
+    })
+
+    await expect(
+      testDestination.testAction('identify', {
+        event,
+        mapping: inleadsIdentifyData,
+        settings: {
+          apiKey: API_KEY
+        }
+      })
+    ).resolves.not.toThrowError()
+  })
+
+  test('Should throw an error if apiKey is not defined', async () => {
+    const event = createTestEvent({
+      type: 'identify',
+      traits: {
+        name: 'test',
+        email: 'test@company.com'
+      },
+      properties: {
+        timezone: 'America/New_York'
+      },
+      userId: '123456'
+    })
+
+    await expect(
+      testDestination.testAction('identify', {
+        event,
+        mapping: inleadsIdentifyData,
+        settings: {
+          apiKey: API_KEY
+        }
+      })
+    ).rejects.toThrowError()
+  })
+
+  test('Should send an identify event to InleadsAI', async () => {
+    // Mock: Segment Identify Call
+    nock("https://server.inleads.ai")
+      .post('/events/track', {
+        apiKey: API_KEY
+      })
+      .reply(200, { success: true })
+
+    const event = createTestEvent({
+      type: 'identify',
+      traits: {
+        name: 'test',
+        email: 'test@company.com'
+      },
+      properties: {
+        timezone: 'America/New_York'
+      },
+      userId: '123456'
+    })
+
+    const responses = await testDestination.testAction('identify', {
+      event,
+      mapping: inleadsIdentifyData,
+      useDefaultMappings: true,
+      settings: {
+        apiKey: API_KEY
+      }
+    })
+
+    expect(responses[0].status).toEqual(200)
+  })
+})

--- a/packages/destination-actions/src/destinations/inleads-ai/identify/index.ts
+++ b/packages/destination-actions/src/destinations/inleads-ai/identify/index.ts
@@ -1,0 +1,121 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings, Payload } from '../generated-types'
+import { commonFields } from '../common-fields'
+import { IntegrationBaseUrl, IntegrationName } from '../contants'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Identify',
+  description: `Send identify calls to ${IntegrationName}.`,
+  defaultSubscription: 'type = "identify"',
+  platform: 'cloud',
+  fields: {
+    user_id: {
+      type: 'string',
+      required: true,
+      description: 'The External ID of the user',
+      label: 'User ID',
+      default: { '@path': '$.userId' }
+    },
+    name: {
+      type: 'string',
+      required: false,
+      description: "The user's name",
+      allowNull: true,
+      label: 'Name',
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.name' },
+          then: { '@path': '$.traits.name' },
+          else: { '@path': '$.properties.name' }
+        }
+      }
+    },
+    first_name: {
+      type: 'string',
+      required: false,
+      allowNull: true,
+      description: "The user's first name. This field is mandatory if you're not providing a name field",
+      label: 'First name',
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.first_name' },
+          then: { '@path': '$.traits.first_name' },
+          else: { '@path': '$.properties.first_name' }
+        }
+      }
+    },
+    last_name: {
+      type: 'string',
+      required: false,
+      allowNull: true,
+      description: "The user's last name. This field is mandatory if you're not providing a name field",
+      label: 'Last name',
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.last_name' },
+          then: { '@path': '$.traits.last_name' },
+          else: { '@path': '$.properties.last_name' }
+        }
+      }
+    },
+    email: {
+      type: 'string',
+      required: false,
+      description: "The user's email address",
+      label: 'Email address',
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.email' },
+          then: { '@path': '$.traits.email' },
+          else: { '@path': '$.properties.email' }
+        }
+      }
+    },
+    account_id: {
+      type: 'string',
+      required: false,
+      description: 'The account id, to uniquely identify the account associated with the user',
+      label: 'Account id',
+      default: {
+        '@if': {
+          exists: { '@path': '$.context.group_id' },
+          then: { '@path': '$.context.group_id' },
+          else: { '@path': '$.groupId' }
+        }
+      }
+    },
+    created_at: {
+      type: 'string',
+      required: false,
+      description:
+        'The timestamp when the user was created, represented in the ISO-8601 date format. For instance, "2023-09-26T15:30:00Z".',
+      label: 'Created at',
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.created_at' },
+          then: { '@path': '$.traits.created_at' },
+          else: { '@path': '$.traits.createdAt' }
+        }
+      }
+    },
+    traits: {
+      type: 'object',
+      label: 'Traits',
+      description: 'Properties to associate with the user',
+      required: false,
+      default: { '@path': '$.traits' }
+    },
+    ...commonFields
+  },
+  perform: (request, data) => {
+    return request(`${IntegrationBaseUrl}/events/track`, {
+      method: 'post',
+      headers: {
+        Authorization: `Basic ${data.settings.apiKey}`
+      },
+      json: {} // validateInput(data.settings, data.payload, 'track')
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/inleads-ai/index.ts
+++ b/packages/destination-actions/src/destinations/inleads-ai/index.ts
@@ -1,0 +1,71 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import { defaultValues } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+import track from './track'
+import group from './group'
+import identify from './identify'
+import {
+  IntegrationBaseUrl,
+  IntegrationName,
+  IntegrationWebsite,
+  PartnerActionName
+} from './contants'
+
+const destination: DestinationDefinition<Settings> = {
+  name: IntegrationName,
+  slug: 'inleads-ai',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      apiKey: {
+        label: 'API Key',
+        description: `Your ${IntegrationName} API Key. You can find your API Key in your ${IntegrationWebsite} settings.`,
+        type: 'password',
+        required: true
+      }
+    },
+    testAuthentication: async (request, { settings }) => {
+      const AUTH_KEY = settings.apiKey;
+      return await request(`${IntegrationBaseUrl}/events/validate/key`, {
+        method: 'post',
+        headers: {
+          Authorization: `Basic ${AUTH_KEY}`
+        },
+        json: {}
+      })
+    }
+  },
+
+  presets: [
+    {
+      name: 'Track Event',
+      subscribe: 'type = "track"',
+      partnerAction: PartnerActionName,
+      mapping: defaultValues(track.fields),
+      type: 'automatic'
+    },
+    {
+      name: 'Group',
+      subscribe: 'type = "group"',
+      partnerAction: PartnerActionName,
+      mapping: defaultValues(group.fields),
+      type: 'automatic'
+    },
+    {
+      name: 'Identify User',
+      subscribe: 'type = "identify"',
+      partnerAction: PartnerActionName,
+      mapping: defaultValues(identify.fields),
+      type: 'automatic'
+    }
+  ],
+  actions: {
+    identify,
+    group,
+    track
+  }
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/inleads-ai/track/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/inleads-ai/track/__tests__/index.test.ts
@@ -1,0 +1,100 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import { API_KEY } from '../../__tests__/index.test'
+
+const testDestination = createTestIntegration(Destination)
+
+beforeAll(() => {
+  nock.disableNetConnect()
+})
+
+afterAll(() => {
+  nock.enableNetConnect()
+  nock.cleanAll()
+})
+
+const inleadsData = {
+  event_name: {
+    '@path': '$.event'
+  },
+  properties: {
+    '@path': '$.properties'
+  },
+  user_id: {
+    '@path': '$.userId'
+  },
+  account_id: {
+    '@path': '$.groupId'
+  }
+}
+
+describe('InleadsAI.track', () => {
+  test('Should throw an error if `event_name` is not defined', async () => {
+    const event = createTestEvent({
+      type: 'track',
+      properties: {
+        recency: 'Now'
+      },
+      event: 'INIT'
+    })
+
+    await expect(
+      testDestination.testAction('track', {
+        event,
+        mapping: inleadsData
+      })
+    ).rejects.toThrowError()
+  })
+
+  test('Should throw an error if apiKey is not defined', async () => {
+    const event = createTestEvent({
+      type: 'track',
+      properties: {
+        recency: 'Now'
+      },
+      event: 'VISIT'
+    })
+
+    await expect(
+      testDestination.testAction('track', {
+        event,
+        mapping: inleadsData,
+        settings: {
+          apiKey: API_KEY
+        }
+      })
+    ).rejects.toThrowError()
+  })
+
+  test('Should send an track event to InleadsAI', async () => {
+    // Mock: Segment track Call
+    nock("https://server.inleads.ai")
+      .post('/events/track', {
+        apiKey: API_KEY,
+        eventName: "VISIT",
+        email: "test@inleads.ai",
+        name: "Tester",
+        options: {},
+      })
+      .reply(200, { success: true })
+
+    const event = createTestEvent({
+      type: 'track',
+      properties: {
+        recency: 'Now'
+      },
+      event: 'VISIT'
+    })
+
+    const responses = await testDestination.testAction('track', {
+      event,
+      mapping: inleadsData,
+      settings: {
+        apiKey: API_KEY
+      }
+    })
+
+    expect(responses[0].status).toEqual(200)
+  })
+})

--- a/packages/destination-actions/src/destinations/inleads-ai/track/index.ts
+++ b/packages/destination-actions/src/destinations/inleads-ai/track/index.ts
@@ -1,0 +1,65 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings, Payload } from '../generated-types'
+import { commonFields } from '../common-fields'
+import { IntegrationBaseUrl, IntegrationName } from '../contants'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Track',
+  description: `Send track calls to ${IntegrationName}.`,
+  defaultSubscription: 'type = "track"',
+  fields: {
+    eventName: {
+      type: 'string',
+      required: true,
+      description: 'The name of the event',
+      label: 'Event name',
+      default: { '@path': '$.event' }
+    },
+    user_id: {
+      type: 'string',
+      required: true,
+      description: 'The user id, to uniquely identify the user associated with the event',
+      label: 'User id',
+      default: { '@path': '$.userId' }
+    },
+    account_id: {
+      type: 'string',
+      required: false,
+      description: 'The account id, to uniquely identify the account associated with the user',
+      label: 'Account id',
+      default: {
+        '@if': {
+          exists: { '@path': '$.context.groupId' },
+          then: { '@path': '$.context.groupId' },
+          else: { '@path': '$.groupId' }
+        }
+      }
+    },
+    properties: {
+      type: 'object',
+      required: false,
+      description: 'The properties of the track call',
+      label: 'Event properties',
+      default: { '@path': '$.properties' }
+    },
+    traits: {
+      type: 'object',
+      required: false,
+      description: 'The Traits of the track call',
+      label: 'Event Traits',
+      default: { '@path': '$.traits' }
+    },
+    ...commonFields
+  },
+  perform: (request, data) => {
+    return request(`${IntegrationBaseUrl}/events/track`, {
+      method: 'post',
+      headers: {
+        Authorization: `Basic ${data.settings.apiKey}`
+      },
+      json: { ...data.payload, apiKey: data.settings.apiKey }
+    })
+  }
+}
+
+export default action


### PR DESCRIPTION
A new action destination for Inleads. It provides two actions:

Send Identify which maps Identify events by default
Send tRACK which maps TRACK events by default.

The destination introduces actions for Segment events.

Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ]  [Segmenters] Tested in the staging environment